### PR TITLE
Add support for Maya 2015, PropertyNames on root joint, and reference namespace removal

### DIFF
--- a/Source/BuildMayaPlugin.xml
+++ b/Source/BuildMayaPlugin.xml
@@ -10,6 +10,10 @@
       <Compile Target="UnrealHeaderTool" Platform="Win64" Configuration="Development" Arguments="-precompile -nodebuginfo"/>
     </Node>
 
+    <Node Name="Compile Maya 2015 Win64" Requires="Compile UnrealHeaderTool Win64">
+      <Compile Target="MayaLiveLinkPlugin2015" Platform="Win64" Configuration="Development" />
+    </Node>
+
     <Node Name="Compile Maya 2016 Win64" Requires="Compile UnrealHeaderTool Win64">
       <Compile Target="MayaLiveLinkPlugin2016" Platform="Win64" Configuration="Development" />
     </Node>
@@ -26,9 +30,13 @@
       <Compile Target="MayaLiveLinkPlugin2019" Platform="Win64" Configuration="Development" />
     </Node>
 	
-	<Node Name="Stage Maya Plugin Module" Requires="Compile Maya 2016 Win64;Compile Maya 2017 Win64;Compile Maya 2018 Win64;Compile Maya 2019 Win64">
+	<Node Name="Stage Maya Plugin Module" Requires="Compile Maya 2015 Win64;Compile Maya 2016 Win64;Compile Maya 2017 Win64;Compile Maya 2018 Win64;Compile Maya 2019 Win64">
 		<Copy From="$(LocalSourceDir)\ReadMe.txt" To="$(LocalStagingDir)\MayaLiveLink\ReadMe.txt" />
-	
+
+		<Copy From="$(LocalBinaryDir)\2015\MayaLiveLinkPlugin2015.mll" To="$(LocalStagingDir)\MayaLiveLink\Binaries\2015\MayaLiveLinkPlugin2015.mll" />
+		<Copy From="$(LocalSourceDir)\MayaLiveLinkUI.py" To="$(LocalStagingDir)\MayaLiveLink\Binaries\2015\MayaLiveLinkUI.py" />
+		<Copy From="$(LocalSourceDir)\LiveLink.mod" To="$(LocalStagingDir)\MayaLiveLink\Binaries\2015\LiveLink.mod" />
+
 		<Copy From="$(LocalBinaryDir)\2016\MayaLiveLinkPlugin2016.mll" To="$(LocalStagingDir)\MayaLiveLink\Binaries\2016\MayaLiveLinkPlugin2016.mll" />
 		<Copy From="$(LocalSourceDir)\MayaLiveLinkUI.py" To="$(LocalStagingDir)\MayaLiveLink\Binaries\2016\MayaLiveLinkUI.py" />
 		<Copy From="$(LocalSourceDir)\LiveLink.mod" To="$(LocalStagingDir)\MayaLiveLink\Binaries\2016\LiveLink.mod" />

--- a/Source/MayaLiveLinkPlugin.cpp
+++ b/Source/MayaLiveLinkPlugin.cpp
@@ -26,6 +26,9 @@ IMPLEMENT_APPLICATION(MayaLiveLinkPlugin, "MayaLiveLinkPlugin");
 
 // Maya includes
 // For Maya 2016 the SDK has to be downloaded and installed manually for these includes to work.
+#ifndef BananaFritters
+#define BananaFritters unsigned int
+#endif
 #define DWORD BananaFritters
 #include <maya/MObject.h>
 #include <maya/MGlobal.h>

--- a/Source/MayaLiveLinkPlugin.cpp
+++ b/Source/MayaLiveLinkPlugin.cpp
@@ -454,6 +454,19 @@ public:
 	}
 };
 
+MString StripMayaNamespace(const MString& name)
+{
+	std::string stdname = name.asChar();
+	int charindex = stdname.rfind(":");
+	if (charindex != std::string::npos)
+	{
+		charindex++;
+		return stdname.substr(charindex).c_str();
+	}
+
+	return name;
+}
+
 struct FLiveLinkStreamedJointHierarchySubject : IStreamedEntity
 {
 	FLiveLinkStreamedJointHierarchySubject(FName InSubjectName, MDagPath InRootPath)
@@ -563,8 +576,7 @@ struct FLiveLinkStreamedJointHierarchySubject : IStreamedEntity
 				status = JointIterator.getPath(JointPath);
 				MFnIkJoint JointObject(JointPath);
 
-				FName JointName(JointObject.name().asChar());
-
+				FName JointName(StripMayaNamespace(JointObject.name()).asChar());
 				JointsToStream.Add(FStreamHierarchy(JointName, JointPath, ParentIndex));
 				AnimationData.BoneNames.Add(JointName);
 				AnimationData.BoneParents.Add(ParentIndex);
@@ -661,7 +673,7 @@ private:
 	MDagPath RootDagPath;
 	TArray<FStreamHierarchy> JointsToStream;
 	FStreamedUserDefinedAttributes StreamedAttributes;
-	
+
 	const TArray<FString> CharacterStreamOptions = { TEXT("Root Only"), TEXT("Full Hierarchy") };
 	enum FCharacterStreamMode
 	{

--- a/Source/MayaLiveLinkPlugin2015.Build.cs
+++ b/Source/MayaLiveLinkPlugin2015.Build.cs
@@ -1,0 +1,11 @@
+// Copyright 1998-2019 Epic Games, Inc. All Rights Reserved.
+using UnrealBuildTool;
+
+public class MayaLiveLinkPlugin2015 : MayaLiveLinkPluginBase
+{
+	public MayaLiveLinkPlugin2015(ReadOnlyTargetRules Target) : base(Target)
+	{
+	}
+
+	public override string GetMayaVersion() { return "2015"; }
+}

--- a/Source/MayaLiveLinkPlugin2015.Target.cs
+++ b/Source/MayaLiveLinkPlugin2015.Target.cs
@@ -1,0 +1,9 @@
+// Copyright 1998-2019 Epic Games, Inc. All Rights Reserved.
+using UnrealBuildTool;
+
+public class MayaLiveLinkPlugin2015Target : MayaLiveLinkPluginTargetBase
+{
+	public MayaLiveLinkPlugin2015Target(TargetInfo Target) : base(Target, "2015")
+	{
+	}
+}

--- a/Source/MayaLiveLinkUI.py
+++ b/Source/MayaLiveLinkUI.py
@@ -19,7 +19,7 @@ def OnRemoveSubject(SubjectPath):
 	RefreshSubjects()
 
 def CreateSubjectTable():
-	cmds.rowColumnLayout("SubjectLayout", numberOfColumns=5,  adjustableColumn=2, columnWidth=[(1, 20), (2,80), (3, 100), (4, 180), (5, 120)], columnOffset=[(1, 'right', 5), (2, 'right', 10), (4, 'left', 10)], parent="SubjectWrapperLayout")
+	cmds.rowColumnLayout("SubjectLayout", numberOfColumns=5, columnWidth=[(1, 20), (2,80), (3, 100), (4, 180), (5, 120)], columnOffset=[(1, 'right', 5), (2, 'right', 10), (4, 'left', 10)], parent="SubjectWrapperLayout")
 	cmds.text(label="")
 	cmds.text(label="Subject Type", font="boldLabelFont", align="left")
 	cmds.text(label="Subject Name", font="boldLabelFont", align="left")


### PR DESCRIPTION
The changes below have been compiled with the latest 4.23 source. The features has been tested with Maya 2015 with the launcher version of 4.23. A full character with custom attributes are streaming as intended. The curve debugger displays the curve values and an animation blueprint is successfully driving a pose asset using the curve names.

**Maya 2015 support** 6ee2e07
Added Build.cs and Target.cs for 2015.
Updated BuildMayaPlugin.xml to include 2015 target.
Added ```#ifndef #def``` in MayaLiveLinkPlugin.cpp as the missing type BananaFritters caused compilation to fail for 2015.
Removed ```adjustableColumn=2``` for ```cmds.rowColumnLayout("SubjectLayout",...)``` in MayaLiveLinkUI.py as the attribute does not exist in Maya 2015.

**Stream custom attributes on root joint as PropertyName curves** 51c6d8d
I have replicated the FBX-export behavior that exports custom curves for user defined attributes on the root bone. (Full Hierarchy only) Any user defined attribute that is visible, and not locked, will be streamed. (with or without keyframes) This allows for driven behaviors or manual sliding. If _exclude-attribute-when-locked_ happens to be a poor design choice, it can simply be changed in one if-statement. Adding UI support for which attributes to stream should be a small change if needed.

The subject will be rebuilt if the user adds, removes, locks or unlocks the attributes on the root joint. 

Most of the heavy lifting is done in a new ```FStreamedUserDefinedAttributes``` class. A private member instance ```StreamedAttributes``` is added to ```FLiveLinkStreamedJointHierarchySubject``` to keep track of the attributes. RebuildSubjectData() and OnStream() triggers StreamedAttributes to update AnimationData.

***Remove reference namespace for joint names*** 753dea2
If a subject is part of a referenced scene in Maya it will get a reference prefix like so: ```Filename:Subject``` or potentially ```File1:File2:...:Subject```. This fix removes the namespace so that only the transform name is streamed.

Namespaces are automatically removed from the skeletal mesh when importing an FBX in the editor. I see no reason why the default behavior of the LiveLink plugin should behave differently. Especially when we have the ability to stream multiple subjects with unique identifiers.